### PR TITLE
@js helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-mocha-test": "~0.2.0",
     "should": "~1.2.2",
-    "grunt-simple-mocha": "~0.4.0"
+    "grunt-simple-mocha": "~0.4.0",
+    "moment": "~2.5.1"
   }
 }

--- a/src/helpers/control/js/README.md
+++ b/src/helpers/control/js/README.md
@@ -7,18 +7,22 @@ This is very universal helper inspired by [jstemplate](https://code.google.com/p
 Different functionality is executed based on first parameter used.
 
 Value of all parameters is JavaScript expression. It is compiled and executed with access to JavaScript global, dust global and current scope data.
-The ```this``` keyword in expression is current ```chunk```. Expression is wrapped with ```with (ctx_.global) with (data_)```
-so you have access to global ans scope data without prefixing them. To access the data explicitly you may use ```ctx_``` or ```data_``` variables in expression.
+The ```this``` keyword in expression is current ```chunk```. Expression is wrapped with ```with (ctx_.global) with (data_) with (loopData_)```
+so you have access to global and scope data without prefixing them. To access the data explicitly you may use ```ctx_```, ```data_``` or ```loopData_``` variables in expression.
 
-## Definition 
+Special variable ```$this``` (different as this!) is the same as ```data_``` and ```contex.stack.head```. Other dust helpers use "." instead of $this variable.
+
+The for parameter adds to context ```$key```, ```$value``` and ```$type``` variables, their meaning is the same as in @iterate helper.
+
+## Definitions
 
 ```
 {@js expr="<JS expression>" /}
 {@js for="<JS expression>"}{$key}-{$value} of type {$type}{/js}
 {@js if="<JS expression>"}evaluated to true{:else}evaluated to false{/js}
-{@js case="<JS expression>"}
+{@js switch="<JS expression>"}
 {:a}
-if result was b
+if result was a
 {:b}
 if result was b
 {:else}
@@ -26,9 +30,10 @@ if defined, any result different from a and b will render this line
 {/js}
 ```
 
-Variables $key, $value, and $type are defined within the iteration block
-
 ## Example
+
+See tests in ```js-*-test.js``` files for more examples and usage possibilities.
+
 ```
               Data: { today: new Date(), title: "Famous People", names: [{ "name": "Larry", "age": 20 },{ "name": "Curly", "age": 30 },{ "name": "Moe", "age": 40 }] }
 

--- a/src/helpers/control/js/README.md
+++ b/src/helpers/control/js/README.md
@@ -30,9 +30,9 @@ Variables $key, $value, and $type are defined within the iteration block
 
 ## Example
 ```
-              Data: { title: "Famous People", names: [{ "name": "Larry", "age": 20 },{ "name": "Curly", "age": 30 },{ "name": "Moe", "age": 40 }] }
+              Data: { today: new Date(), title: "Famous People", names: [{ "name": "Larry", "age": 20 },{ "name": "Curly", "age": 30 },{ "name": "Moe", "age": 40 }] }
 
-              {title}
+              {title} - {@js expr="moment(today).format('dd.MM.YYYY')" /}
               <ul>
                 {#names}
                   <li>{@js expr="'-'+name"/}</li>{~n}

--- a/src/helpers/control/js/README.md
+++ b/src/helpers/control/js/README.md
@@ -1,0 +1,70 @@
+# js helper
+
+EXPERIMENTAL !!! open to discussion
+
+This is very universal helper inspired by [jstemplate](https://code.google.com/p/google-jstemplate/wiki/TemplateProcessingInstructionReference).
+
+Different functionality is executed based on first parameter used.
+
+Value of all parameters is JavaScript expression. It is compiled and executed with access to JavaScript global, dust global and current scope data.
+The ```this``` keyword in expression is current ```chunk```. Expression is wrapped with ```with (ctx_.global) with (data_)```
+so you have access to global ans scope data without prefixing them. To access the data explicitly you may use ```ctx_``` or ```data_``` variables in expression.
+
+## Definition 
+
+```
+{@js expr="<JS expression>" /}
+{@js for="<JS expression>"}{$key}-{$value} of type {$type}{/js}
+{@js if="<JS expression>"}evaluated to true{:else}evaluated to false{/js}
+{@js case="<JS expression>"}
+{:a}
+if result was b
+{:b}
+if result was b
+{:else}
+if defined, any result different from a and b will render this line
+{/js}
+```
+
+Variables $key, $value, and $type are defined within the iteration block
+
+## Example
+```
+              Data: { title: "Famous People", names: [{ "name": "Larry", "age": 20 },{ "name": "Curly", "age": 30 },{ "name": "Moe", "age": 40 }] }
+
+              {title}
+              <ul>
+                {#names}
+                  <li>{@js expr="'-'+name"/}</li>{~n}
+                {/names}
+              </ul>
+
+              Use @js-for
+              <ul>
+                 {@js for="names"}
+                    <li>{$value.name} {@js expr="10+$value.age"/}</li>{~n}
+                 {/js}
+              </ul>
+
+              Output:
+              Famous People
+              -Larry
+              -Curly
+              -Moe
+
+              Use @js-for
+              Larry 30
+              Curly 40
+              Moe 50
+```
+
+## Usage
+Depends on dustjs-helpers module to be loaded first since it requires tap helper.
+
+In node.js:
+require('dustmotes-js');
+
+In browser:
+If not using require, load the JS some other way and call it with the dust object. As noted earlier,
+dustjs-helpers must be loaded earlier.
+

--- a/src/helpers/control/js/README.md
+++ b/src/helpers/control/js/README.md
@@ -2,6 +2,8 @@
 
 EXPERIMENTAL !!! open to discussion
 
+SECURITY !!! this helper uses javascript ```eval/Function```, it is dangerous to use it with untrusted/not compiled templates
+
 This is very universal helper inspired by [jstemplate](https://code.google.com/p/google-jstemplate/wiki/TemplateProcessingInstructionReference).
 
 Different functionality is executed based on first parameter used.

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -67,7 +67,9 @@
                         loopData.$idx = ctx.stack.index;
                         loopData.$len = ctx.stack.of;
                     }
-                    return exprFunction.call(chunk, ctx, ctx.stack.head, loopData);
+                    var data = ctx.stack.isObject ? ctx.stack.head : {};
+                    data.$this = ctx.stack.head;
+                    return exprFunction.call(chunk, ctx, data, loopData);
                 } catch (e) {
                     if (e.name === 'ReferenceError') {
                         var a = e.message.match(/^(\w*)/);

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -55,14 +55,19 @@
                         for (var v in unknownVars) {
                             fixes += 'if (typeof ' + v + ' ==="undefined") fixes_.' + v + '=null;';
                         }
-                        fixes += "with(fixes_){"
+                        fixes += "with(fixes_){";
                         //noinspection JSHint
-                        exprFunction = new Function('ctx_', 'data_', "with (ctx_.global) with (data_) {" + fixes + 'return ' + expr + '}}');
+                        exprFunction = new Function('ctx_', 'data_', 'loopData_', "with (ctx_.global) with (data_) with (loopData_) {" + fixes + 'return ' + expr + '}}');
                         if (useCache) {
                             ctx.global.exprCache[expr] = exprFunction;
                         }
                     }
-                    return exprFunction.call(chunk, ctx, ctx.stack.head);
+                    var loopData = {};
+                    if (ctx.stack.hasOwnProperty('index')) {
+                        loopData.$idx = ctx.stack.index;
+                        loopData.$len = ctx.stack.of;
+                    }
+                    return exprFunction.call(chunk, ctx, ctx.stack.head, loopData);
                 } catch (e) {
                     if (e.name === 'ReferenceError') {
                         var a = e.message.match(/^(\w*)/);
@@ -95,11 +100,11 @@
                 return chunk;
             } else if (result instanceof Array) {
                 for (var i = 0; i < arr.length; i++) {
-
+                    // TODO simulate @iterate
                 }
             } else if (typeof result === 'object') {
                 for (var key in result) {
-
+                    // TODO simulate @iterate
                 }
             } else {
                 _console.log("Value '" + result + "' passed to 'for' helper has to be array or object.");

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -92,6 +92,7 @@
 
         // decide what evaluation function to use
         var jsEval = jsEvalHandleUnknown;
+        var value;
 
         // find out action type and process it
         if (params.hasOwnProperty('expr')) {
@@ -107,13 +108,25 @@
             result = jsEval('for');
             if (result === null) {
                 return chunk;
-            } else if (result instanceof Array) {
-                for (var i = 0; i < arr.length; i++) {
-                    // TODO simulate @iterate
+            } else if (result instanceof Array || typeof result === "string") {
+                for (var i = 0; i < result.length; i++) {
+                    value = result[i];
+                    chunk = body(chunk, ctx.push({
+                        $key: i,
+                        $value: value,
+                        $type: typeof value
+                    }));
                 }
             } else if (typeof result === 'object') {
                 for (var key in result) {
-                    // TODO simulate @iterate
+                    if (result.hasOwnProperty(key)) {
+                        value = result[key];
+                        chunk = body(chunk, ctx.push({
+                            $key: key,
+                            $value: value,
+                            $type: typeof value
+                        }));
+                    }
                 }
             } else {
                 _console.log("Value '" + result + "' passed to 'for' helper has to be array or object.");

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -1,0 +1,1 @@
+/home/k2s/Dev/xtdoc/DocBuilder/DocBuilderWeb/web-app/js/dustjs/js.js

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -150,12 +150,16 @@
                 return chunk.render(bodies['else'], ctx);
             }
 
-        } else if (params.hasOwnProperty('case')) {
-            result = jsEval('case');
+        } else if (params.hasOwnProperty('switch')) {
+            result = jsEval('switch');
             if (bodies.hasOwnProperty(result)) {
                 return chunk.render(bodies[result], ctx);
             } else {
-                _console.log("Missing body block named '" + result + "' in the 'case' helper!");
+                if (bodies.hasOwnProperty("else")) {
+                    return chunk.render(bodies['else'], ctx);
+                } else {
+                    _console.log("Missing body block named '" + result + "' in the 'case' helper!");
+                }
             }
         }
 

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -25,7 +25,14 @@
                         ctx.global.exprCache[expr] = exprFunction;
                     }
                 }
-                return exprFunction.call(chunk, ctx, ctx.stack.head);
+                var loopData = {};
+                if (ctx.stack.hasOwnProperty('index')) {
+                    loopData.$idx = ctx.stack.index;
+                    loopData.$len = ctx.stack.of;
+                }
+                var data = ctx.stack.isObject ? ctx.stack.head : {};
+                data.$this = ctx.stack.head;
+                return exprFunction.call(chunk, ctx, data, loopData);
             } catch (e) {
                 _console.log('jsEvalToFunction (' + expr + ') EXCEPTION ' + e);
                 return undefined;

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -1,1 +1,83 @@
-/home/k2s/Dev/xtdoc/DocBuilder/DocBuilderWeb/web-app/js/dustjs/js.js
+/*globals dust, _console */
+(function(dust) {
+    dust.helpers.js = function(chunk, ctx, bodies, params) {
+        // decide if we will use compiled expression cache stored in ctx.global
+        var result, useCache = !!ctx.global.exprCache;
+
+        // execute JavaScript expression in right context
+        var jsEval = function(action) {
+            var expr = dust.helpers.tap(params[action], chunk, ctx);
+
+            try {
+                // compile expression or use one cached in ctx.global
+                var exprFunction;
+                if (useCache && ctx.global.exprCache[expr]) {
+                    exprFunction = ctx.global.exprCache[expr];
+                } else {
+                    //noinspection JSHint
+                    exprFunction = new Function('ctx_', 'data_', 'with (ctx_.global) with (data_) return ' + expr);
+                    if (useCache) {
+                        ctx.global.exprCache[expr] = exprFunction;
+                    }
+                }
+                return exprFunction.call(chunk, ctx, ctx.stack.head);
+            } catch (e) {
+                _console.log('jsEvalToFunction (' + expr + ') EXCEPTION ' + e);
+                return undefined;
+            }
+        };
+
+        // find out action type and process it
+        if (params.hasOwnProperty('expr')) {
+            result = jsEval('expr');
+            return chunk.write(result);
+
+        } else if (params.hasOwnProperty('for')) {
+            var body = bodies.block;
+            if (!body) {
+                _console.log("Missing body block in the 'for' helper.");
+                return chunk;
+            }
+            result = jsEval('for');
+            if (result === null) {
+                return chunk;
+            } else if (result instanceof Array) {
+                for (var i = 0; i < arr.length; i++) {
+
+                }
+            } else if (typeof result === 'object') {
+                for (var key in result) {
+
+                }
+            } else {
+                _console.log("Value '" + result + "' passed to 'for' helper has to be array or object.");
+                return chunk;
+            }
+
+        } else if (params.hasOwnProperty('if')) {
+            result = jsEval('if');
+            if (result) {
+                if (bodies.hasOwnProperty("block")) {
+                    return chunk.render(bodies.block, ctx);
+                } else {
+                    _console.log("Missing body block in the if helper!");
+                    return chunk;
+                }
+            } else if (bodies.hasOwnProperty('else')) {
+                return chunk.render(bodies['else'], ctx);
+            }
+
+        } else if (params.hasOwnProperty('case')) {
+            result = jsEval('case');
+            if (bodies.hasOwnProperty(result)) {
+                return chunk.render(bodies[result], ctx);
+            } else {
+                _console.log("Missing body block named '" + result + "' in the 'case' helper!");
+            }
+        }
+
+        // not a valid action
+
+        return chunk;
+    };
+})(typeof exports !== 'undefined' ? module.exports = require('dustjs-linkedin') : dust);

--- a/src/helpers/control/js/js.js
+++ b/src/helpers/control/js/js.js
@@ -1,11 +1,16 @@
 /*globals dust, _console */
-(function(dust) {
-    dust.helpers.js = function(chunk, ctx, bodies, params) {
+(function (dust) {
+    dust.helpers.js = function (chunk, ctx, bodies, params) {
         // decide if we will use compiled expression cache stored in ctx.global
         var result, useCache = !!ctx.global.exprCache;
 
-        // execute JavaScript expression in right context
-        var jsEval = function(action) {
+        /**
+         * Evaluate expression in default JavaScript way
+         *
+         * @param action
+         * @returns {*}
+         */
+        var jsEvalPure = function (action) {
             var expr = dust.helpers.tap(params[action], chunk, ctx);
 
             try {
@@ -26,6 +31,53 @@
                 return undefined;
             }
         };
+
+        /**
+         * Evaluate expression with handling of unknown variable names
+         *
+         * @param action
+         * @returns {*}
+         */
+        var jsEvalHandleUnknown = function (action) {
+            var expr = dust.helpers.tap(params[action], chunk, ctx);
+            var unknownVars = {}, repeat;
+
+            do {
+                repeat = false;
+                try {
+                    // compile expression or use one cached in ctx.global
+                    var exprFunction;
+                    if (!repeat && useCache && ctx.global.exprCache[expr]) {
+                        exprFunction = ctx.global.exprCache[expr];
+                    } else {
+                        // build fix for JavaScript undefined exceptions
+                        var fixes = "var fixes_ = {};";
+                        for (var v in unknownVars) {
+                            fixes += 'if (typeof ' + v + ' ==="undefined") fixes_.' + v + '=null;';
+                        }
+                        fixes += "with(fixes_){"
+                        //noinspection JSHint
+                        exprFunction = new Function('ctx_', 'data_', "with (ctx_.global) with (data_) {" + fixes + 'return ' + expr + '}}');
+                        if (useCache) {
+                            ctx.global.exprCache[expr] = exprFunction;
+                        }
+                    }
+                    return exprFunction.call(chunk, ctx, ctx.stack.head);
+                } catch (e) {
+                    if (e.name === 'ReferenceError') {
+                        var a = e.message.match(/^(\w*)/);
+                        unknownVars[a[0]] = null;
+                        repeat = true;
+                    } else {
+                        _console.log('jsEvalToFunction (' + expr + ') EXCEPTION ' + e);
+                        return undefined;
+                    }
+                }
+            } while (repeat);
+        };
+
+        // decide what evaluation function to use
+        var jsEval = jsEvalHandleUnknown;
 
         // find out action type and process it
         if (params.hasOwnProperty('expr')) {
@@ -56,7 +108,11 @@
 
         } else if (params.hasOwnProperty('if')) {
             result = jsEval('if');
-            if (result) {
+            if (result === undefined && bodies.hasOwnProperty("unknown")) {
+                // @if returns empty string for unknown,
+                // but we do evaluate to false if :unknown block is not defined
+                return chunk.render(bodies['unknown'], ctx);
+            } else if (result) {
                 if (bodies.hasOwnProperty("block")) {
                     return chunk.render(bodies.block, ctx);
                 } else {

--- a/src/helpers/control/js/package.json
+++ b/src/helpers/control/js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dustmotes-js",
+  "version": "0.0.1",
+  "author": "Martin Minka",
+  "description": "JavaScript evaluation helper",
+  "main": "./js.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rragan/dust-motes.git"
+  },
+  "license": "UNLICENSE",
+  "engine": {
+    "node": ">=0.5"
+  }
+}

--- a/test/js-expr-test.js
+++ b/test/js-expr-test.js
@@ -1,0 +1,32 @@
+/*global _console: true */
+_console = console;
+dust = require('dustjs-linkedin');
+require('dustjs-helpers');
+require('../src/helpers/control/js');
+var moment = require('moment');
+var assert = require('assert');
+
+
+describe("@JS 'expr' tests", function () {
+    it('simple variable', function () {
+        var context = { v: "A"};
+        var code = '{@js expr="v" /}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, 'A');
+        });
+    });
+    it('little bit of math', function () {
+        var context = {};
+        var code = '{@js expr="2*2" /}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, '4');
+        });
+    });
+    it('use moment library', function () {
+        var context = {moment:moment};
+        var code = '{@js expr="moment(\'Dec 25, 1995\').format(\'DD.MM.YYYY\')" /}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, '25.12.1995');
+        });
+    });
+});

--- a/test/js-for-test.js
+++ b/test/js-for-test.js
@@ -1,0 +1,94 @@
+/*global _console: true */
+_console = console;
+dust = require('dustjs-linkedin');
+require('dustjs-helpers');
+require('../src/helpers/control/js');
+var assert = require('assert');
+
+var sortObjDesc = function (old) {
+    var n = {};
+    Object.keys(old).sort().reverse().forEach(function (k) {
+        n[k] = old[k]
+    });
+    return n;
+};
+
+var sortObjAsc = function (old) {
+    var n = {};
+    Object.keys(old).sort().forEach(function (k) {
+        n[k] = old[k]
+    });
+    return n;
+};
+
+//var compareNumbers = function (a, b) {
+//    var aa = parseInt(a, 10);
+//    var bb = parseInt(b, 10);
+//    return aa - bb;
+//};
+
+describe("@JS 'for' tests", function () {
+    it('simple object iteration', function () {
+        var context = { obj: {a: "A", b: "B", c: "C" } };
+        var code = '{@js for="obj"}{$key}:{$value} {$type} {/js}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, 'a:A string b:B string c:C string ');
+        });
+    });
+    it('iterate ascending sort', function () {
+        var context = { obj: {c: "C", a: "A", b: "B" } };
+        var base = dust.makeBase({"sortObjAsc": sortObjAsc});
+        var code = '{@js for="sortObjAsc(obj)"}{$key}:{$value} {/js}';
+        dust.renderSource(code, base.push(context), function (err, out) {
+            assert.equal(out, 'a:A b:B c:C ');
+        });
+    });
+    it('iterate descending sort', function () {
+        var context = { obj: {c: "C", a: "A", b: "B" } };
+        var base = dust.makeBase({"sortObjDesc": sortObjDesc});
+        var code = '{@js for="sortObjDesc(obj)"}{$key}:{$value} {/js}';
+        dust.renderSource(code, base.push(context), function (err, out) {
+            assert.equal(out, 'c:C b:B a:A ');
+        });
+    });
+    /*
+    it('iterate no key param (doesn't work because of mocha ignoreLeaks: false)', function () {
+        var context = { };
+        var code = '{@js for="foo=1"}{$key}{/js}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, '');
+        });
+    });*/
+    it('iterate helper pass array obj for key', function () {
+        var context = {arr: [1, 2, 3]};
+        var code = '{@js for="arr"}{$key}:{$value} {/js}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, '0:1 1:2 2:3 ');
+        });
+    });
+    it('iterate helper pass string obj for key', function () {
+        var context = {name: "dust"};
+        var code = '{@js for="name"}{$key}:{$value} {/js}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, '0:d 1:u 2:s 3:t ');
+        });
+    });
+    it('iterate with user-supplied compare function for numeric sort', function () {
+        var context = { obj: {10: "C", 1: "A", 300: "B" } };
+        // seams to work out of box without sorting
+//        var base = dust.makeBase({"compareNumbers": compareNumbers});
+//        sort="compareNumbers"
+        var code = '{@js for="obj"}{$key}:{$value} {/js}';
+        dust.renderSource(code, context /*base.push(context)*/, function (err, out) {
+            assert.equal(out, '1:A 10:C 300:B ');
+        });
+    });
+    it('iterate helper showing types', function () {
+        var context = { obj: {a: "A", b: 2, c: [1, 2], d: {a: 4}, e: true, f: null, g: undefined, h: function f() {
+        }} };
+        var code = '{@js for="obj"}{$key} {$type} {/js}';
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, 'a string b number c object d object e boolean f object g undefined h function ');
+        });
+    });
+});

--- a/test/js-if-test.js
+++ b/test/js-if-test.js
@@ -1,0 +1,636 @@
+/*global _console: true */
+_console = console;
+/*global dust: true */
+require('dustjs-linkedin');
+require('dustjs-helpers');
+require('../src/helpers/control/js');
+var assert = require('assert');
+
+describe('@JS tests', function () {
+    it("if/test helper simple name", function () {
+        var code = '{@js if="x"}3{/js}';
+        var context = {
+            x: 1
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "3");
+        });
+    });
+    it("if/test helper with path", function () {
+        var code = '{@js if="a.b.c.d == 5"}5{/js}';
+        var context = {
+            a: {
+                b: {
+                    c: {
+                        d: 5
+                    }
+                }
+            }
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "5");
+        });
+    });
+    it("if/test helper with path in bracket", function () {
+        var code = '{@js if="arr[nums[1]]==3"}3{/js}';
+        var context = {
+            "arr": [1, 2, 3],
+            nums: [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "3");
+        });
+    });
+
+    it("if/test helper with parenthesized expr in bracket", function () {
+        var code = '{@js if="arr[(1&&0)]"}2{/js}';
+        var context = {
+            "arr": [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "2");
+        });
+    });
+    it("if/test helper with path with expr in bracket", function () {
+        var code = '{@js if="arr[1&&0]"}2{/js}';
+        var context = {
+            "arr": [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "2");
+        });
+    });
+    it("if/test helper with array with bracket in path", function () {
+        var code = '{@js if="arr[0].biz==\'123\'"}123{/js}{$idx}';
+        var context = {
+            "arr": [
+                {
+                    "biz": "123"
+                },
+                {
+                    "biz": "345"
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "123");
+        });
+    });
+    it("if/test helper with path with bracket", function () {
+        var code = '{@js if="arr[1]==2"}2{/js}';
+        var context = {
+            "arr": [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "2");
+        });
+    });
+    it("if/test helper with no body", function () {
+        var code = '{@js if="{x}<{y}"/}';
+        var context = {
+            x: 2,
+            y: 3
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if/test helper with else using the and condition", function () {
+        var code = '{@js if="( {x} ) && ({x}==1)"}<div> X exists and is 1 </div>{:else}<div> x is not there </div>{/js}';
+        var context = {
+            x: 1
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X exists and is 1 </div>");
+        });
+    });
+    it("if/test helper test all relational ops", function () {
+        var code = '{@js if="2>1 && 3>=3 && 4==4 && 5!=6 && 8>7 && 9>=9 && 10>=9 && 9<=10"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper without else", function () {
+        var code = '{@js if="{x}<{y}"}X < Y{/js}';
+        var context = {
+            x: 2,
+            y: 3
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "X < Y");
+        });
+    });
+    it("if/test helper short-circuit and test ", function () {
+        var code = '{@js if="x && x.y"}x.y worked?{:else}false expected{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false expected");
+        });
+    });
+    it("if/test helper short-circuit and test explicit undefined", function () {
+        var code = '{@js if="x && x.y"}x.y worked?{:else}false expected{/js}';
+        var context = {
+            x: undefined
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false expected");
+        });
+    });
+    it("if/test helper short-circuit or test", function () {
+        var code = '{@js if="x || y"}true expected{:else}false wrong{/js}';
+        var context = {
+            x: true
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true expected");
+        });
+    });
+
+/*
+    it("if/test helper short-circuit or test explicit undefined", function () {
+        var code = '{@js if="x || y || z"}true expected{:else}false wrong{/js}';
+        var context = {
+            x: undefined,
+            z: true
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true expected");
+        });
+    });
+*/
+
+    it("if/test helper without else using direct names", function () {
+        var code = '{@js if="x<y"}<div> X < Y </div>{/js}';
+        var context = {
+            x: 2,
+            y: 3
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X < Y </div>");
+        });
+    });
+    it("if/test helper with else block && operator", function () {
+        var code = '{@js if=" \'{x}\' && \'{y}\' "}<div> X and Y exists </div>{:else}<div> X and Y does not exists </div>{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X and Y does not exists </div>");
+        });
+    });
+    it("if/test helper with else block && operator and direct names", function () {
+        var code = '{@js if=" x && y "}<div> X and Y exists </div>{:else}<div> X and Y does not exists </div>{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X and Y does not exists </div>");
+        });
+    });
+    it("if/test helper with else using the or condition", function () {
+        var code = '{@js if=" \'{x}\' || \'{y}\' "}<div> X or Y exists </div>{:else}<div> X or Y does not exists </div>{/js}';
+        var context = {
+            x: 1
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X or Y exists </div>");
+        });
+    });
+    it("if/test helper with strings", function () {
+        var code = '{@js if="\'abc\' == \'abc\'"}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "1");
+        });
+    });
+    it("if/test helper with strings NEQ", function () {
+        var code = '{@js if="\'abc\' != \'abc\'"}1{:else}0{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "0");
+        });
+    });
+    it("if/test helper with use of just number", function () {
+        var code = '{@js if=".25"}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "1");
+        });
+    });
+    it("if/test helper with hex operands", function () {
+        var code = '{@js if="0xf < 0x10"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper with negative operand", function () {
+        var code = '{@js if="-5 < -4"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper with float values", function () {
+        var code = '{@js if=".5 < 0.6e+0"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper with other float values", function () {
+        var code = '{@js if="5e1 < 6.0e+1"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper with negative float values", function () {
+        var code = '{@js if="-.5 < -0.6e+0"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false");
+        });
+    });
+/*
+    it("if/test helper with use of .name", function () {
+        var code = '{#arr}{@js if=".val == $idx"}{$idx}{/js}{/arr}';
+        var context = {
+            arr: [
+                {
+                    "val": 0
+                },
+                {
+                    "val": 1
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "01");
+        });
+    });
+
+    it("if/test helper with use of . for current value", function () {
+        var code = '{#arr}{@js if=". < 4"}1{/js}{/arr}';
+        var context = {
+            arr: [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "111");
+        });
+    });
+    it("if/test helper with array with bracket and dot name", function () {
+        var code = '{#arr}{@js if=".[0]==$idx"}{$idx}{/js}{/arr}';
+        var context = {
+            "arr": [
+                [0],
+                [1]
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "01");
+        });
+    });
+*/
+    it("if/test helper with unary operator", function () {
+        var code = '{@js if="!0"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper test all relational ops", function () {
+        var code = '{@js if="2>1 && 3>=3 && 4==4 && 5!=6 && 8>7 && 9>=9 && 10>=9 && 9<=10"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper test all relational ops using names", function () {
+        var code = '{@js if="two>one && three>=three && four==four && five!=six && eight>seven && nine>=nine && ten>=nine && nine<=ten"}true{/js}';
+        var context = {
+            "one": 1,
+            "two": 2,
+            "three": 3,
+            "four": 4,
+            "five": 5,
+            "six": 6,
+            "seven": 7,
+            "eight": 8,
+            "nine": 9,
+            "ten": 10
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper test all relational ops using paths", function () {
+        var code = '{@js if="a.two>a.one && a.three>=a.three && a.four==a.four && a.five!=a.six && a.eight>a.seven && a.nine>=a.nine && a.ten>=a.nine && a.nine<=a.ten"}true{/js}';
+        var context = {
+            a: {
+                "one": 1,
+                "two": 2,
+                "three": 3,
+                "four": 4,
+                "five": 5,
+                "six": 6,
+                "seven": 7,
+                "eight": 8,
+                "nine": 9,
+                "ten": 10
+            }
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper test NOT all relational ops and parens", function () {
+        var code = '{@js if="!(2>1 && 3>=3 && 4==4 && 5!=6 && 8>7 && 9>=9 && 10>=9 && 9<=10)"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false");
+        });
+    });
+    it("if/test helper with precedence", function () {
+        var code = '{@js if="!0 && 5==5"}true{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper adjacent operators OK ||", function () {
+        var code = '{@js if="(((4)<2) || (1))"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "true");
+        });
+    });
+    it("if/test helper adjacent operators OK &&", function () {
+        var code = '{@js if="(((4)<2) && (1))"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false");
+        });
+    });
+    it("if/test helper with double unary", function () {
+        var code = '{@js if="!!0"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "false");
+        });
+    });
+/*
+    it("if/test helper with empty brackets err", function () {
+        var code = '{@js if="arr[]"}true{:else}false{/js}';
+        var context = {
+            arr: [1, 2, 3]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+    it("if/test helper with empty parens - error case", function () {
+        var code = '{@js if="()"}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if/test helper with invalid expression - error case", function () {
+        var code = '{@js if="2[7]"}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if/test helper using $idx", function () {
+        var code = '{#list}{@js if="( {$idx} == 1 )"}<div>{y}</div>{/js}{/list}';
+        var context = {
+            x: 1,
+            list: [
+                {
+                    y: 'foo'
+                },
+                {
+                    y: 'bar'
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div>bar</div>");
+        });
+    });
+/*
+    it("if/test helper using direct $idx", function () {
+        var code = '{#list}{@js if=" $idx == 1 "}<div>{y}</div>{/js}{/list}';
+        var context = {
+            x: 1,
+            list: [
+                {
+                    y: 'foo'
+                },
+                {
+                    y: 'bar'
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div>bar</div>");
+        });
+    });
+    it("if/test helper using direct $len", function () {
+        var code = '{#list}{@js if=" $len == 2 "}2{/js}{/list}';
+        var context = {
+            x: 1,
+            list: [
+                {
+                    y: 'foo'
+                },
+                {
+                    y: 'bar'
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "22");
+        });
+    });
+*/
+/*
+    it("if/test helper with array with bad syntax", function () {
+        var code = '{@js if="arr.[0]==\'123\'"}123{/js}{$idx}';
+        var context = {
+            "arr": [
+                [
+                    {
+                        "biz": "123"
+                    }
+                ],
+                [
+                    {
+                        "biz": "345"
+                    }
+                ]
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with consecutive operands", function () {
+        var code = '{@js if="2 3"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with bad operator", function () {
+        var code = '{@js if="2*3"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with unclosed string", function () {
+        var code = '{@js if="\'abc"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if/test helper with unclosed string", function () {
+        var code = '{@js if="\'abc"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with invalid number - bad exponent", function () {
+        var code = '{@js if="3.25D+27"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with invalid number double dots", function () {
+        var code = '{@js if="3..1"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with consecutive periods", function () {
+        var code = '{@js if=".."}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with invalid number", function () {
+        var code = '{@js if="3.25.8"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with use of a. - invalid name", function () {
+        var code = '{@js if="a."}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+/*
+    it("if/test helper with use of a..b - invalid name", function () {
+        var code = '{@js if="a..b"}1{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if/test helper with consecutive operators", function () {
+        var code = '{@js if="==||"}true{:else}false{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+*/
+    it("if helper with no body using tap", function () {
+        var code = '{@js if="{x}<{y}"/}';
+        var context = {
+            x: 2,
+            y: 3
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "");
+        });
+    });
+    it("if helper without else using tap", function () {
+        var code = '{@js if="{x}<{y}"}<div> X < Y </div>{/js}';
+        var context = {
+            x: 2,
+            y: 3
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X < Y </div>");
+        });
+    });
+    it("if helper with else block using tap", function () {
+        var code = '{@js if=" \'{x}\' && \'{y}\' "}<div> X and Y exists </div>{:else}<div> X and Y does not exists </div>{/js}';
+        var context = {};
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X and Y does not exists </div>");
+        });
+    });
+    it("if helper with else using the or condition using tap", function () {
+        var code = '{@js if=" \'{x}\' || \'{y}\'"}<div> X or Y exists </div>{:else}<div> X or Y does not exists </div>{/js}';
+        var context = {
+            x: 1
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X or Y exists </div>");
+        });
+    });
+    it("if helper with else using the and conditon using tap", function () {
+        var code = '{@js if="( \'{x}\') && ({x}<3)"}<div> X exists and is 1 </div>{:else}<div> x is not there </div>{/js}';
+        var context = {
+            x: 1
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div> X exists and is 1 </div>");
+        });
+    });
+    it("if helper using $idx using tap", function () {
+        var code = '{#list}{@js if="( {$idx} == 1 )"}<div>{y}</div>{/js}{/list}';
+        var context = {
+            x: 1,
+            list: [
+                {
+                    y: 'foo'
+                },
+                {
+                    y: 'bar'
+                }
+            ]
+        };
+        dust.renderSource(code, context, function (err, out) {
+            assert.equal(out, "<div>bar</div>");
+        });
+    });
+});

--- a/test/js-if-test.js
+++ b/test/js-if-test.js
@@ -147,7 +147,6 @@ describe('@JS tests', function () {
         });
     });
 
-/*
     it("if/test helper short-circuit or test explicit undefined", function () {
         var code = '{@js if="x || y || z"}true expected{:else}false wrong{/js}';
         var context = {
@@ -158,7 +157,6 @@ describe('@JS tests', function () {
             assert.equal(out, "true expected");
         });
     });
-*/
 
     it("if/test helper without else using direct names", function () {
         var code = '{@js if="x<y"}<div> X < Y </div>{/js}';
@@ -266,7 +264,6 @@ describe('@JS tests', function () {
             assert.equal(out, "01");
         });
     });
-
     it("if/test helper with use of . for current value", function () {
         var code = '{#arr}{@js if=". < 4"}1{/js}{/arr}';
         var context = {
@@ -376,9 +373,9 @@ describe('@JS tests', function () {
             assert.equal(out, "false");
         });
     });
-/*
-    it("if/test helper with empty brackets err", function () {
-        var code = '{@js if="arr[]"}true{:else}false{/js}';
+    it("if/test helper with empty brackets err (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="arr[]"}true{:else}false{:unknown}{/js}';
         var context = {
             arr: [1, 2, 3]
         };
@@ -386,7 +383,7 @@ describe('@JS tests', function () {
             assert.equal(out, "");
         });
     });
-*/
+
     it("if/test helper with empty parens - error case", function () {
         var code = '{@js if="()"}1{/js}';
         var context = {};
@@ -454,7 +451,6 @@ describe('@JS tests', function () {
         });
     });
 */
-/*
     it("if/test helper with array with bad syntax", function () {
         var code = '{@js if="arr.[0]==\'123\'"}123{/js}{$idx}';
         var context = {
@@ -475,60 +471,54 @@ describe('@JS tests', function () {
             assert.equal(out, "");
         });
     });
-*/
-/*
-    it("if/test helper with consecutive operands", function () {
-        var code = '{@js if="2 3"}true{:else}false{/js}';
+    it("if/test helper with consecutive operands (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="2 3"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
-/*
-    it("if/test helper with bad operator", function () {
+    it("if/test helper with bad operator (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if: why should this be wrong ? JS will evaluate 2*3 as TRUE
         var code = '{@js if="2*3"}true{:else}false{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
-            assert.equal(out, "");
+            assert.equal(out, "true");
         });
     });
-*/
-/*
-    it("if/test helper with unclosed string", function () {
-        var code = '{@js if="\'abc"}true{:else}false{/js}';
+    it("if/test helper with unclosed string (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="\'abc"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-    it("if/test helper with unclosed string", function () {
-        var code = '{@js if="\'abc"}true{:else}false{/js}';
+    it("if/test helper with unclosed string (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="\'abc"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
-/*
-    it("if/test helper with invalid number - bad exponent", function () {
-        var code = '{@js if="3.25D+27"}true{:else}false{/js}';
+    it("if/test helper with invalid number - bad exponent (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="3.25D+27"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
-/*
-    it("if/test helper with invalid number double dots", function () {
-        var code = '{@js if="3..1"}true{:else}false{/js}';
+    it("if/test helper with invalid number double dots (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="3..1"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
-/*
     it("if/test helper with consecutive periods", function () {
         var code = '{@js if=".."}1{/js}';
         var context = {};
@@ -536,17 +526,14 @@ describe('@JS tests', function () {
             assert.equal(out, "");
         });
     });
-*/
-/*
-    it("if/test helper with invalid number", function () {
-        var code = '{@js if="3.25.8"}true{:else}false{/js}';
+    it("if/test helper with invalid number (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="3.25.8"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
-/*
     it("if/test helper with use of a. - invalid name", function () {
         var code = '{@js if="a."}1{/js}';
         var context = {};
@@ -554,8 +541,6 @@ describe('@JS tests', function () {
             assert.equal(out, "");
         });
     });
-*/
-/*
     it("if/test helper with use of a..b - invalid name", function () {
         var code = '{@js if="a..b"}1{/js}';
         var context = {};
@@ -563,14 +548,14 @@ describe('@JS tests', function () {
             assert.equal(out, "");
         });
     });
-    it("if/test helper with consecutive operators", function () {
-        var code = '{@js if="==||"}true{:else}false{/js}';
+    it("if/test helper with consecutive operators (INCOMPATIBLE with @if)", function () {
+        // INCOMPATIBLE with @if, use empty :unknown to achieve the same result
+        var code = '{@js if="==||"}true{:else}false{:unknown}{/js}';
         var context = {};
         dust.renderSource(code, context, function (err, out) {
             assert.equal(out, "");
         });
     });
-*/
     it("if helper with no body using tap", function () {
         var code = '{@js if="{x}<{y}"/}';
         var context = {

--- a/test/js-if-test.js
+++ b/test/js-if-test.js
@@ -1,12 +1,12 @@
 /*global _console: true */
 _console = console;
 /*global dust: true */
-require('dustjs-linkedin');
+dust = require('dustjs-linkedin');
 require('dustjs-helpers');
 require('../src/helpers/control/js');
 var assert = require('assert');
 
-describe('@JS tests', function () {
+describe("@JS 'if' tests", function () {
     it("if/test helper simple name", function () {
         var code = '{@js if="x"}3{/js}';
         var context = {

--- a/test/js-if-test.js
+++ b/test/js-if-test.js
@@ -415,7 +415,6 @@ describe('@JS tests', function () {
             assert.equal(out, "<div>bar</div>");
         });
     });
-/*
     it("if/test helper using direct $idx", function () {
         var code = '{#list}{@js if=" $idx == 1 "}<div>{y}</div>{/js}{/list}';
         var context = {
@@ -450,7 +449,6 @@ describe('@JS tests', function () {
             assert.equal(out, "22");
         });
     });
-*/
     it("if/test helper with array with bad syntax", function () {
         var code = '{@js if="arr.[0]==\'123\'"}123{/js}{$idx}';
         var context = {

--- a/test/js-if-test.js
+++ b/test/js-if-test.js
@@ -247,9 +247,8 @@ describe('@JS tests', function () {
             assert.equal(out, "false");
         });
     });
-/*
-    it("if/test helper with use of .name", function () {
-        var code = '{#arr}{@js if=".val == $idx"}{$idx}{/js}{/arr}';
+    it("if/test helper with use of $this.name (INCOMPATIBLE with @if)", function () {
+        var code = '{#arr}{@js if="$this.val == $idx"}{$idx}{/js}{/arr}';
         var context = {
             arr: [
                 {
@@ -264,8 +263,8 @@ describe('@JS tests', function () {
             assert.equal(out, "01");
         });
     });
-    it("if/test helper with use of . for current value", function () {
-        var code = '{#arr}{@js if=". < 4"}1{/js}{/arr}';
+    it("if/test helper with use of $this for current value (INCOMPATIBLE with @if)", function () {
+        var code = '{#arr}{@js if="$this < 4"}1{/js}{/arr}';
         var context = {
             arr: [1, 2, 3]
         };
@@ -273,8 +272,8 @@ describe('@JS tests', function () {
             assert.equal(out, "111");
         });
     });
-    it("if/test helper with array with bracket and dot name", function () {
-        var code = '{#arr}{@js if=".[0]==$idx"}{$idx}{/js}{/arr}';
+    it("if/test helper with array with bracket and $this.name (INCOMPATIBLE with @if)", function () {
+        var code = '{#arr}{@js if="$this[0]==$idx"}{$idx}{/js}{/arr}';
         var context = {
             "arr": [
                 [0],
@@ -285,7 +284,6 @@ describe('@JS tests', function () {
             assert.equal(out, "01");
         });
     });
-*/
     it("if/test helper with unary operator", function () {
         var code = '{@js if="!0"}true{/js}';
         var context = {};

--- a/test/js-switch-test.js
+++ b/test/js-switch-test.js
@@ -1,0 +1,33 @@
+/*global _console: true */
+_console = console;
+dust = require('dustjs-linkedin');
+require('dustjs-helpers');
+require('../src/helpers/control/js');
+var assert = require('assert');
+
+describe("@JS 'switch' tests", function () {
+    it('first block', function () {
+        var code = '{@js switch="v"}{:a}a{:b}b{/js}';
+        dust.renderSource(code, {v: "a"}, function (err, out) {
+            assert.equal(out, 'a');
+        });
+    });
+    it('second block', function () {
+        var code = '{@js switch="v"}{:a}a{:b}b{/js}';
+        dust.renderSource(code, {v: "b"}, function (err, out) {
+            assert.equal(out, 'b');
+        });
+    });
+    it("doesn't match", function () {
+        var code = '{@js switch="v"}{:a}a{:b}b{/js}';
+        dust.renderSource(code, {v: "c"}, function (err, out) {
+            assert.equal(out, '');
+        });
+    });
+    it("doesn't match, but has else", function () {
+        var code = '{@js switch="v"}{:a}a{:b}b{:else}else{/js}';
+        dust.renderSource(code, {v: "c"}, function (err, out) {
+            assert.equal(out, 'else');
+        });
+    });
+});


### PR DESCRIPTION
related to https://github.com/linkedin/dustjs-helpers/issues/74

possible extensions to Dust core (which would of course change Dust far from logic-less):
- create functions from expressions to compiled version of template (performance improvement and easy debugging}
- add special Dust language element to eliminate need to wrap expressions to quotes `{!if people.size()>10}many{:else}acceptable{/if}` or `{! "{" + moment(today).format('dd.MM.YYYY') + "}" }`
